### PR TITLE
Always check params as string in interceptor

### DIFF
--- a/lib/api/interceptor.js
+++ b/lib/api/interceptor.js
@@ -71,7 +71,7 @@ class XHRInterceptor {
     for (let key of parameters) {
       const regex = responseParams[key] ? new RegExp(responseParams[key]) : null;
 
-      if (regex && requestParams[key].match && !requestParams[key].match(regex)) {
+      if (regex && requestParams[key] && !requestParams[key].toString().match(regex)) {
         return false;
       }
     }


### PR DESCRIPTION
This is done due to the fact that we want to match params using regex to enable wildcard requests.

For example if we have the following request:

http://example.com
With a body of
accountId=1

And another with a body of
accountId=2

We want to be able match the request by specifying accountId=* in BDSM which will catch all Ids sent to this request.

 Closes #100