### PR TITLE
Treat requests params as strings.

### DIFF
--- a/lib/api/interceptor.js
+++ b/lib/api/interceptor.js
@@ -21,11 +21,10 @@ class XHRInterceptor {
       }
 
       const mockedRequests = Scenarios.getCurrentMockedRequests();
-
       for (let mockedRequest of mockedRequests) {
         const methodsMatch = request.method === mockedRequest.method;
         const urlsMatch    = request.url === mockedRequest.url;
-        const paramsMatch  = this.checkParamsEquality(request.body, mockedRequest.params);
+        const paramsMatch  = request.body === mockedRequest.params;
 
         if (methodsMatch && urlsMatch && paramsMatch && mockedRequest.active) {
           return this.buildResponse(responder, mockedRequest.getResponse(mockedRequest.selectedStateId), request);

--- a/lib/api/migrations/index.js
+++ b/lib/api/migrations/index.js
@@ -1,0 +1,30 @@
+import cloneDeep from 'lodash/lang/cloneDeep';
+
+const upgrades = [
+  '1.0.0',
+  '1.0.1'
+];
+
+export function migrateData(data) {
+  let upgradedData = cloneDeep(data);
+
+  const versionIndex   = upgrades.indexOf(data.version);
+  const upgradeProcess = upgrades.slice(versionIndex + 1, versionIndex.length);
+
+  upgradeProcess.forEach((version) => {
+    console.log(`BDSM: migrating from version ${data.version} to ${version}`);
+
+    try {
+      const { migrate } = require(`api/migrations/migration-${version}`);
+
+      if (migrate) {
+        upgradedData = migrate(upgradedData);
+      }
+    } catch (error) {
+      console.error(`FAILED TO MIGRATE TO ${version}`);
+      console.error(error);
+    }
+  });
+
+  return upgradedData;
+}

--- a/lib/api/migrations/migration-1.0.1.js
+++ b/lib/api/migrations/migration-1.0.1.js
@@ -1,0 +1,46 @@
+import isObject from 'lodash/lang/isObject';
+import isArray  from 'lodash/lang/isArray';
+
+export function migrate(data) {
+
+  data.version = '1.0.1';
+
+  // migrate request params to string instead of objects
+  Object.assign(data, {
+    mockedRequests: transformRequestParamsToString(data.mockedRequests)
+  });
+
+  // migrate request hash to use string parameters
+  Object.assign(data, {
+    mockedRequests: transformRequestHashToStringParams(data.mockedRequests)
+  });
+
+  return data;
+}
+
+function transformRequestParamsToString(mockedRequests) {
+  return mockedRequests.map((mockedRequest) => {
+    if (isObject(mockedRequest.params) || isArray(mockedRequest.params)) {
+      mockedRequest.params = JSON.stringify(mockedRequest.params);
+
+      // cancel previous default value
+      if (mockedRequest.params === '{}') {
+        mockedRequest.params = null;
+      }
+    }
+
+    return mockedRequest;
+  });
+}
+
+function transformRequestHashToStringParams(mockedRequests) {
+  return mockedRequests.map((mockedRequest) => {
+    mockedRequest.requestHash = [
+      mockedRequest.method,
+      mockedRequest.url,
+      mockedRequest.params
+    ].join('|');
+
+    return mockedRequest;
+  });
+}

--- a/lib/api/models/request.js
+++ b/lib/api/models/request.js
@@ -15,11 +15,7 @@ export class Request {
   }
 
   buildRequestHash(params = '') {
-    const requestHash = [`${ params }`];
-
-    requestHash.unshift(this.method, this.url);
-
-    return requestHash.join('|');
+    return [this.method, this.url, params].join('|');
   }
 
   buildMockedRequestData() {

--- a/lib/api/models/request.js
+++ b/lib/api/models/request.js
@@ -14,9 +14,8 @@ export class Request {
     });
   }
 
-  buildRequestHash(params = {}) {
-    const requestHash = Object.keys(params)
-      .map((paramKey) => `${ paramKey }=${ JSON.stringify(params[paramKey]) }`);
+  buildRequestHash(params = '') {
+    const requestHash = [`${ params }`];
 
     requestHash.unshift(this.method, this.url);
 
@@ -38,7 +37,7 @@ export class Request {
     return {
       method: this.method,
       url: this.url,
-      params: Object.assign({}, this.params),
+      params: this.params,
       headers: Object.assign({}, this.headers),
       requestHash: this.requestHash,
       states: [defaultState]

--- a/lib/api/requests.js
+++ b/lib/api/requests.js
@@ -9,7 +9,7 @@ export default class Requests {
     const capturedRequest = new Request({
       method: request.method,
       url: request.url,
-      params: UrlUtils.parseRequestBody(request.body),
+      params: request.body,
       headers: request.headers,
       response: {
         status: response.status,

--- a/lib/api/storage.js
+++ b/lib/api/storage.js
@@ -1,9 +1,11 @@
 const STORAGE_KEY = `_bdsm`;
 import Emitter from 'api/emitter';
 import EVENTS from 'api/constants/events';
+import semver from 'semver';
+import { migrateData } from 'api/migrations';
 
 const dataTree = {
-  version: '1.0.0',
+  version: '1.0.1',
   mockedRequests: [],
   scenarios: [],
   currentScenario: 'MockedRequests'
@@ -19,7 +21,16 @@ class PersistentStorageSingleton {
   }
 
   _loadFromStorage() {
-    Object.assign(dataTree, this.getSerialized());
+    const data = this.getSerialized();
+    
+    if (semver.lt(data.version, dataTree.version)) {
+      const newData = migrateData(data);
+      Object.assign(dataTree, newData);
+      this.persist();
+      return;
+    }
+
+    Object.assign(dataTree, data);
   }
 
   persist() {

--- a/lib/ui/components/details-panel/request-details.js
+++ b/lib/ui/components/details-panel/request-details.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import isObject from 'lodash/lang/isObject';
 
 import { MethodLabel } from 'ui/components/method-label';
 import { Url } from 'ui/components/url';

--- a/lib/ui/components/details-panel/request-details.js
+++ b/lib/ui/components/details-panel/request-details.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import isObject from 'lodash/lang/isObject';
 
 import { MethodLabel } from 'ui/components/method-label';
 import { Url } from 'ui/components/url';
@@ -8,46 +9,21 @@ export class RequestDetails extends React.Component {
   static get propTypes() {
     return {
       request: React.PropTypes.object.isRequired,
-      onParamChange: React.PropTypes.func,
       readOnly: React.PropTypes.bool
     }
   }
 
-  _changeParam(paramKey, event) {
-    this.props.onParamChange(paramKey, event.target.value);
-  }
-
-  _parameter(paramKey) {
-    if (this.props.readOnly) {
-      return (
-        <div key={ paramKey }>
-          <b>{ paramKey }</b>:
-          <span className="wrap-text">{ this.props.request.params[paramKey] }</span>
-        </div>
-      );
-    }
-
-    return (
-      <div key={ paramKey }>
-        { paramKey }:
-        <input type="text"
-               onChange={ this._changeParam.bind(this, paramKey) }
-               value={ this.props.request.params[paramKey] }/>
-      </div>
-    );
-  }
-
   _parameters() {
-    const paramKeys = Object.keys(this.props.request.params);
+    const { request } = this.props;
 
-    if (!paramKeys.length) {
+    if (!request.params) {
       return null;
     }
 
     return (
       <div>
-        Parameters:
-        { paramKeys.map((key) => this._parameter(key)) }
+        <p>Parameters:</p>
+        <textarea defaultValue={ request.params } />
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-dom": "0.14.3",
     "react-notification-system": "0.2.6",
     "react-select": "0.9.1",
+    "semver": "5.1.0",
     "urijs": "1.17.0",
     "uuid": "2.0.1",
     "xhook": "1.3.3"


### PR DESCRIPTION
An HTTP request is combined of string fields.
We should not make any assumption about the type of content of an HTTP request not in the response body or the request body.

This is done because of the following reasons:
1  We could mess up with the type assumption and break a request (which was this use case).

2  We should treat a request as its original value, if we wish to change that value then we need to respect its original structure.

This means that if we want to we can handle different content types in the UI in order to display the parameters in a cleaner way for specific supported types and avoid trying to support all of them because that is not possible without incredible amount of work.

3  Treating this as a string will help us going forward dynamic templates for responses as we will only need to compile the end result back to a string regardless of the content type.