### PR TITLE
fix(export): Remove an incorrect check of the content type

### DIFF
--- a/lib/api/models/mocked-request.js
+++ b/lib/api/models/mocked-request.js
@@ -62,20 +62,18 @@ export class MockedRequest {
 
   export() {
     const mock = Object.assign({}, this);
-    const mockHeaders = mock.headers['content-type'] || '';
-    if (mockHeaders.indexOf('application/json') > -1) {
-      try {
-        mock.params = JSON.parse(mock.params);
-      } catch (ex) {
-        // failed to parse params, reverting to string
-      }
+
+    try {
+      mock.params = JSON.parse(mock.params);
+    } catch (ex) {
+      // failed to parse params, reverting to string
+    }
 
 
-      try {
-        mock.response.body = JSON.parse(mock.response.body);
-      } catch (ex) {
-        // failed to parse body, reverting to string
-      }
+    try {
+      mock.response.body = JSON.parse(mock.response.body);
+    } catch (ex) {
+      // failed to parse body, reverting to string
     }
 
     return mock;


### PR DESCRIPTION
to attempt parsing request parameters

Before this fix, only mocks that returned a content type of application/json would parse the request

parameters and request body due to a wrong assumption. if a request was sent using json request

parameters (json body) but the server would return a different response type, such as text/html the

check will fail and return an incorrect export file.