### PR TITLE
chore(scripts): Streamline the npm run test:integration command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "NODE_ENV=test node_modules/.bin/karma start --single-run",
     "tdd": "NODE_ENV=test node_modules/.bin/karma start",
     "start:integration-server": "http-server .",
-    "test:integration": "nightwatch"
+    "test:integration": "npm run build ; npm run start:integration-server & nightwatch ; pkill node"
   },
   "files": [
     "dist/bdsm.js",


### PR DESCRIPTION
the test:integration command now builds the project, opens an http server, runs the tests and kills

the http server process in the end instead of having to do these steps manually